### PR TITLE
[riscv32] adding clang in lowrisc toolchain

### DIFF
--- a/toolchains/compilers/lowrisc_toolchain_rv32imc/lowrisc_toolchain_rv32imc_repository.bzl
+++ b/toolchains/compilers/lowrisc_toolchain_rv32imc/lowrisc_toolchain_rv32imc_repository.bzl
@@ -19,7 +19,7 @@ def _com_lowrisc_toolchain_rv32imc_repository_impl(repository_ctx):
     else:
         os = "linux"
     response = repository_ctx.execute(include_tools.ShellCommand(
-        "bin/riscv32-unknown-elf-cpp" + postfix,
+        "bin/riscv32-unknown-elf-clang++" + postfix,
         [
             "-specs=nano.specs",
             "-specs=nosys.specs",
@@ -57,7 +57,7 @@ lowrisc_toolchain_rv32imc_repository = repository_rule(
     attrs = {
         "version": attr.string(
             default = "9",
-            doc = "GCC version, version 9 currently only version supported",
+            doc = "Clang version, version 11 currently only version supported, it depends on lib/gcc 9.2.0 as far as I know",
             values = TOOLCHAIN_VERSIONS.keys(),
         ),
     },

--- a/toolchains/features/common/impl/clang.bzl
+++ b/toolchains/features/common/impl/clang.bzl
@@ -60,26 +60,51 @@ def ClangIncludeFeature(include_paths, sysroot):
 def ClangAchitectureFeature(architecture, float_abi, endian, fpu):
     if fpu == "none":
         fpu = "auto"
-    _ARCHITECTURE_FEATURE = feature(
-        name = "architecture",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = _CPP_ALL_COMPILE_ACTIONS + _C_ALL_COMPILE_ACTIONS +
-                          _LD_ALL_ACTIONS,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            # Set the system architecture/cpu
-                            "-march=" + architecture,
-                            # Set the endianess of the architecture
-                            "-m{}-endian".format(endian),
-                        ],
-                    ),
-                ],
-            ),
-        ],
-    )
+    if architecture == 'riscv32':
+        _ARCHITECTURE_FEATURE = feature(
+            name = "architecture",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = _CPP_ALL_COMPILE_ACTIONS + _C_ALL_COMPILE_ACTIONS +
+                              _LD_ALL_ACTIONS,
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                # Set the system architecture/cpu
+                                "-march=rv32imc",
+                                "-mabi=ilp32",
+                                "-mcmodel=medany",
+                                # FIXME, I look like I'm formatted differently here from below.
+                                # TODO find what here is supported in lowrisc clang and try to make it as consistent with below conditional
+                                "-m{}-endian".format(endian),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+    else:
+        _ARCHITECTURE_FEATURE = feature(
+            name = "architecture",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = _CPP_ALL_COMPILE_ACTIONS + _C_ALL_COMPILE_ACTIONS +
+                              _LD_ALL_ACTIONS,
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                # Set the system architecture/cpu
+                                "-march=" + architecture,
+                                # Set the endianess of the architecture
+                                "-m{}-endian".format(endian),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
     return _ARCHITECTURE_FEATURE
 
 _ALL_WARNINGS_FEATURE = feature(

--- a/toolchains/features/embedded/defs.bzl
+++ b/toolchains/features/embedded/defs.bzl
@@ -1,7 +1,9 @@
 load("//toolchains/features/embedded/impl:gcc.bzl", "GetGccEmbeddedFeatures")
+load("//toolchains/features/embedded/impl:clang.bzl", "GetClangEmbeddedFeatures")
 
 _IMPL_LOOKUP = {
     "GCC": GetGccEmbeddedFeatures,
+    "CLANG": GetClangEmbeddedFeatures,
 }
 
 def GetEmbeddedFeatures(compiler, architecture, float_abi, endian, fpu):

--- a/toolchains/features/embedded/impl/clang.bzl
+++ b/toolchains/features/embedded/impl/clang.bzl
@@ -1,0 +1,157 @@
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+)
+load("//toolchains/features/embedded:type.bzl", "all_embedded_features")
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+_CPP_ALL_COMPILE_ACTIONS = [
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.lto_backend,
+    ACTION_NAMES.clif_match,
+]
+
+_C_ALL_COMPILE_ACTIONS = [
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.c_compile,
+]
+
+_LD_ALL_ACTIONS = [
+    ACTION_NAMES.cpp_link_executable,
+]
+
+# Run time type information is enabled by default
+_RUNTIME_TYPE_INFORMATION_FEATURE = feature(
+    name = "runtime_type_information",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = _CPP_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        # Disable runtime type information
+                        "-fno-rtti",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+_EXCEPTIONS_FEATURE = feature(
+    name = "exceptions",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = _CPP_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        # Disable Exceptions
+                        "-fno-exceptions",
+                        "-fno-non-call-exceptions",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+def _GetSysSpecFeature(architecture, float_abi, endian, fpu):
+    # FIXME(cfrantz): elevate this to device specs?
+    if architecture == "riscv32":
+        compiler_flags = [
+            "-march=rv32imc",
+            "-mabi=ilp32",
+            "-mcmodel=medany",
+        ]
+    else:
+        compiler_flags = [
+            "-mabi=aapcs",
+            "-mthumb",
+            "-specs=nano.specs",
+            "-specs=nosys.specs",
+        ]
+
+    return feature(
+        name = "sys_spec",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = _CPP_ALL_COMPILE_ACTIONS,
+                flag_groups = [
+                    flag_group(
+                        flags = compiler_flags,
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = _LD_ALL_ACTIONS,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            # Disable Exceptions
+                            # FIXME(cfrantz): elevate this to device specs?
+                            #"-lc",
+                            "-lnosys",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+_CC_CONSTRUCTOR_DESTRUCTOR_FEATURE = feature(
+    name = "cc_constructor_destructor",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = _CPP_ALL_COMPILE_ACTIONS + _C_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        # Indicate that this program may not neccesarily be able to use standard system calls
+                        "-ffreestanding",
+                        # Instantiate global variables only once
+                        "-fno-common",
+                        # Emits guards against functions that have references to local array definitions
+                        # FIXME(cfrantz): elevate this to device specs?
+                        #"-fstack-protector-strong",
+                    ],
+                ),
+            ],
+        ),
+        flag_set(
+            actions = _CPP_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        # Disable teardown/destructors for static variables
+                        "-fno-use-cxa-atexit",
+                        # Disable threadsafe statics
+                        "-fno-threadsafe-statics",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+def GetClangEmbeddedFeatures(architecture, float_abi, endian, fpu):
+    """ GetClangEmbeddedFeatures returns features relevant to embedded developement
+    """
+    return all_embedded_features(
+        exceptions = _EXCEPTIONS_FEATURE,
+        runtime_type_information = _RUNTIME_TYPE_INFORMATION_FEATURE,
+        sys_spec = _GetSysSpecFeature(architecture, float_abi, endian, fpu),
+        cc_constructor_destructor = _CC_CONSTRUCTOR_DESTRUCTOR_FEATURE,
+    )

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/BUILD
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/BUILD
@@ -1,0 +1,7 @@
+filegroup(
+    name = "all",
+    srcs = [
+        "//toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix:all",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/BUILD
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/BUILD
@@ -1,0 +1,44 @@
+# MIT License
+#
+# Copyright (c) 2019 Nathaniel Brough
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all",
+    srcs = [
+        "ar",
+        "cpp",
+        "gcc",
+        "ld",
+        "nm",
+        "objcopy",
+        "objdump",
+        "strip",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "objcopy_alias",
+    srcs = ["objcopy"],
+    visibility = ["//visibility:public"],
+)

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/README.md
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/README.md
@@ -1,0 +1,20 @@
+Pointing to contents of meson-riscv32-unknown-elf-clang as a starting point
+
+This is how it looks when installed in my system (comments are mine)
+```
+[binaries]
+c = '/tools/riscv/bin/riscv32-unknown-elf-clang'
+
+# Meson uses the following to point to clang++ so in bazel we'll refer to this
+# as c++ or gcc
+cpp = '/tools/riscv/bin/riscv32-unknown-elf-clang++'
+
+ar = '/tools/riscv/bin/riscv32-unknown-elf-ar'
+ld = '/tools/riscv/bin/riscv32-unknown-elf-ld'
+c_ld = '/tools/riscv/bin/riscv32-unknown-elf-ld'
+cpp_ld = '/tools/riscv/bin/riscv32-unknown-elf-ld'
+objdump = '/tools/riscv/bin/riscv32-unknown-elf-objdump'
+objcopy = '/tools/riscv/bin/riscv32-unknown-elf-objcopy'
+strip = '/tools/riscv/bin/riscv32-unknown-elf-strip'
+as = '/tools/riscv/bin/riscv32-unknown-elf-as'
+```

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/ar
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/ar
@@ -1,0 +1,24 @@
+#!/bin/bash
+# MIT License
+#
+# Copyright (c) 2019 Nathaniel Brough
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+set -euo pipefail
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-ar "$@"

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/cpp
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/cpp
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2019 Nathaniel Brough
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+# Workaround to replace all system includes with user includes
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-clang++ "${@}" -fdiagnostics-color=always 
+#external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-cpp "$@"

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/gcc
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/gcc
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2019 Nathaniel Brough
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+# Workaround to replace all system includes with user includes
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-clang "${@}" -fdiagnostics-color=always 
+#external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-gcc "$@"

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/gcov
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/gcov
@@ -1,0 +1,24 @@
+#!/bin/bash
+# MIT License
+#
+# Copyright (c) 2019 Nathaniel Brough
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+set -euo pipefail
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-gcov "$@"

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/ld
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/ld
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2019 Nathaniel Brough
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-ld "$@"

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/nm
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/nm
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2019 Nathaniel Brough
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-nm "$@"

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/objcopy
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/objcopy
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2019 Nathaniel Brough
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-objcopy "$@"

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/objdump
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/objdump
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2019 Nathaniel Brough
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-objdump "$@"

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/strip
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/strip
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2019 Nathaniel Brough
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-strip "$@"

--- a/toolchains/lowrisc_toolchain_rv32imc/lowrisc_toolchain_rv32imc.bzl
+++ b/toolchains/lowrisc_toolchain_rv32imc/lowrisc_toolchain_rv32imc.bzl
@@ -80,40 +80,40 @@ def _get_additional_system_include_paths(ctx):
 def _lowrisc_toolchain_rv32imc_toolchain_config_info_impl(ctx):
     tool_paths = [
         tool_path(
-            name = "gcc",
-            path = "gcc_wrappers/{os}/gcc",
-        ),
-        tool_path(
-            name = "ld",
-            path = "gcc_wrappers/{os}/ld",
-        ),
-        tool_path(
-            name = "ar",
-            path = "gcc_wrappers/{os}/ar",
-        ),
-        tool_path(
             name = "cpp",
-            path = "gcc_wrappers/{os}/cpp",
+            path = "clang_wrappers/{os}/cpp",
+        ),
+        tool_path(
+            name = "gcc",
+            path = "clang_wrappers/{os}/gcc",
         ),
         tool_path(
             name = "gcov",
-            path = "gcc_wrappers/{os}/gcov",
+            path = "clang_wrappers/{os}/gcov",
+        ),
+        tool_path(
+            name = "ld",
+            path = "clang_wrappers/{os}/ld",
+        ),
+        tool_path(
+            name = "ar",
+            path = "clang_wrappers/{os}/ar",
         ),
         tool_path(
             name = "nm",
-            path = "gcc_wrappers/{os}/nm",
+            path = "clang_wrappers/{os}/nm",
         ),
         tool_path(
             name = "objcopy",
-            path = "gcc_wrappers/{os}/objcopy",
+            path = "clang_wrappers/{os}/objcopy",
         ),
         tool_path(
             name = "objdump",
-            path = "gcc_wrappers/{os}/objdump",
+            path = "clang_wrappers/{os}/objdump",
         ),
         tool_path(
             name = "strip",
-            path = "gcc_wrappers/{os}/strip",
+            path = "clang_wrappers/{os}/strip",
         ),
     ]
     os = "nix"
@@ -124,7 +124,7 @@ def _lowrisc_toolchain_rv32imc_toolchain_config_info_impl(ctx):
     tool_paths = [tool_path(name = t.name, path = t.path.format(os = os) + postfix) for t in tool_paths]
 
     common_features = GetCommonFeatures(
-        compiler = "GCC",
+        compiler = "CLANG",
         architecture = ctx.attr.architecture,
         float_abi = ctx.attr.float_abi,
         endian = ctx.attr.endian,
@@ -135,7 +135,7 @@ def _lowrisc_toolchain_rv32imc_toolchain_config_info_impl(ctx):
         sysroot = None,
     )
     embedded_features = GetEmbeddedFeatures(
-        compiler = "GCC",
+        compiler = "CLANG",
         architecture = ctx.attr.architecture,
         float_abi = ctx.attr.float_abi,
         endian = ctx.attr.endian,
@@ -149,7 +149,7 @@ def _lowrisc_toolchain_rv32imc_toolchain_config_info_impl(ctx):
         target_system_name = "riscv32-unknown-elf",
         target_cpu = ctx.attr.architecture,
         target_libc = "unknown",
-        compiler = "riscv32-unknown-elf-gcc",
+        compiler = "riscv32-unknown-elf-clang",
         abi_version = "unknown",
         abi_libc_version = "unknown",
         tool_paths = tool_paths,
@@ -219,9 +219,9 @@ lowrisc_toolchain_rv32imc_toolchain_config = rule(
             mandatory = True,
             doc = "Indentifier used by the toolchain, this should be consistent with the cc_toolchain rule attribute",
         ),
-        "_gcc_wrappers": attr.label(
-            doc = "Passthrough gcc wrappers used for the compiler",
-            default = "//toolchains/lowrisc_toolchain_rv32imc/gcc_wrappers:all",
+        "_clang_wrappers": attr.label(
+            doc = "Passthrough clang wrappers used for the compiler",
+            default = "//toolchains/lowrisc_toolchain_rv32imc/clang_wrappers:all",
         ),
     },
     provides = [CcToolchainConfigInfo],
@@ -238,7 +238,7 @@ def compiler_components(system_hdr_deps, injected_hdr_deps):
     native.filegroup(
         name = "compiler_components",
         srcs = [
-            "//toolchains/lowrisc_toolchain_rv32imc/gcc_wrappers:all",
+            "//toolchains/lowrisc_toolchain_rv32imc/clang_wrappers:all",
             "@com_lowrisc_toolchain_rv32imc_compiler//:all",
             ":additional_headers",
         ],


### PR DESCRIPTION
not yet working.

* conditional setting of architecture features to defeature a few
  non-critical aspects of the clang toolchain (we do the same in gcc)
* adding a clang embedded toolchain
* added clang_wrappers

Signed-off-by: Drew Macrae <drewmacrae@google.com>