### PR TITLE
[clang] Limit the toolchain directory

### DIFF
--- a/toolchains/compilers/lowrisc_toolchain_rv32imc/lowrisc_toolchain_rv32imc_repository.bzl
+++ b/toolchains/compilers/lowrisc_toolchain_rv32imc/lowrisc_toolchain_rv32imc_repository.bzl
@@ -21,6 +21,7 @@ def _com_lowrisc_toolchain_rv32imc_repository_impl(repository_ctx):
     response = repository_ctx.execute(include_tools.ShellCommand(
         "bin/riscv32-unknown-elf-clang++" + postfix,
         [
+            "--gcc-toolchain=$(pwd)",
             "-specs=nano.specs",
             "-specs=nosys.specs",
         ],

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/cpp
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/cpp
@@ -24,5 +24,7 @@
 
 set -euo pipefail
 # Workaround to replace all system includes with user includes
-external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-clang++ "${@}" -fdiagnostics-color=always 
-#external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-cpp "$@"
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-clang++ \
+    --gcc-toolchain=external/com_lowrisc_toolchain_rv32imc_compiler \
+    -fdiagnostics-color=always \
+    "${@}"

--- a/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/gcc
+++ b/toolchains/lowrisc_toolchain_rv32imc/clang_wrappers/nix/gcc
@@ -24,5 +24,7 @@
 
 set -euo pipefail
 # Workaround to replace all system includes with user includes
-external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-clang "${@}" -fdiagnostics-color=always 
-#external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-gcc "$@"
+external/com_lowrisc_toolchain_rv32imc_compiler/bin/riscv32-unknown-elf-clang \
+    --gcc-toolchain=external/com_lowrisc_toolchain_rv32imc_compiler \
+    -fdiagnostics-color=always \
+    "${@}"


### PR DESCRIPTION
clang seems to find the system compiler if installed.  Use `--gcc-toolchain`
to limit the toolchain to only the lowrisc compilers.

Fixes: lowRISC/opentitan#12016

Signed-off-by: Chris Frantz <cfrantz@google.com>