### PR TITLE
Use official `riscv32` cpu constraint

### DIFF
--- a/constraints/cpu/BUILD
+++ b/constraints/cpu/BUILD
@@ -15,11 +15,3 @@ constraint_value(
     constraint_setting = "@platforms//cpu:cpu",
     visibility = ["//visibility:public"],
 )
-
-# TODO(cfrantz): Upstream to https://github.com/bazelbuild/platforms
-# See https://github.com/bazelbuild/platforms/pull/30.
-constraint_value(
-    name = "riscv32",
-    constraint_setting = "@platforms//cpu:cpu",
-    visibility = ["//visibility:public"],
-)

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -81,9 +81,8 @@ platform(
     name = "opentitan_rv32imc",
     constraint_values = [
         "@bazel_embedded//constraints/fpu:none",
-        "@bazel_embedded//constraints/cpu:riscv32",
-        # TODO(cfrantz): change to this after upstreaming cpu constraints.
-        # See https://github.com/bazelbuild/platforms/pull/30.
+        "@platforms//cpu:riscv32",
+        "@platforms//os:none",
     ],
 )
 

--- a/toolchains/lowrisc_toolchain_rv32imc/lowrisc_toolchain_rv32imc.bzl
+++ b/toolchains/lowrisc_toolchain_rv32imc/lowrisc_toolchain_rv32imc.bzl
@@ -277,8 +277,7 @@ def lowrisc_toolchain_rv32imc_toolchain(name, compiler_components, architecture,
             "@platforms//cpu:x86_64",
         ],
         target_compatible_with = [
-            # TODO(cfrantz): change to platforms package after upstreaming.
-            "@bazel_embedded//constraints/cpu:" + architecture,
+            "@platforms//cpu:" + architecture,
             "//constraints/fpu:" + fpu,
         ],
         toolchain = ":" + name,


### PR DESCRIPTION
- `@platforms//cpu:riscv32` is available in bazelbuild/platforms 0.0.5.

Signed-off-by: Chris Frantz <cfrantz@google.com>