### PR TITLE
[riscv32] Update lowrisc toolchain version to 20220524-1

### DIFF
--- a/toolchains/compilers/lowrisc_toolchain_rv32imc/impl/lowrisc_toolchain_rv32imc_versions.bzl
+++ b/toolchains/compilers/lowrisc_toolchain_rv32imc/impl/lowrisc_toolchain_rv32imc_versions.bzl
@@ -3,9 +3,9 @@ _PLATFORM_SPECIFIC_CONFIGS_9 = {
     "linux": {
         "full_version": "9.2.0",
         "remote_compiler": {
-            "url": "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20210412-1/lowrisc-toolchain-rv32imc-20210412-1.tar.xz",
-            "sha256": "b339d241e9b3cf60d4f81bfdd9da102c4f3889df615e8b6d82e5fba43d36162a",
-            "strip_prefix": "lowrisc-toolchain-rv32imc-20210412-1",
+            "url": "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20220524-1/lowrisc-toolchain-rv32imcb-20220524-1.tar.xz",
+            "sha256": "a4579324083577a0f20cf4b03d11c6a7563265ced0ed2f7b51c3722d80fd24c4",
+            "strip_prefix": "lowrisc-toolchain-rv32imcb-20220524-1",
         },
     },
 }


### PR DESCRIPTION
Updates to the latest toolchain version, with the hardening patches.