### PR TITLE
Update clang.bzl to treat all warnings as errors and to generate annotated disassemblies

### DIFF
--- a/toolchains/features/common/impl/clang.bzl
+++ b/toolchains/features/common/impl/clang.bzl
@@ -262,7 +262,8 @@ _FASTBUILD_FEATURE = feature(
             flag_groups = [
                 flag_group(
                     flags = [
-                        "-O",
+                        "-Os",
+                        "-g",
                     ],
                 ),
             ],

--- a/toolchains/features/common/impl/clang.bzl
+++ b/toolchains/features/common/impl/clang.bzl
@@ -114,7 +114,7 @@ def ClangAchitectureFeature(architecture, float_abi, endian, fpu):
 
 _ALL_WARNINGS_FEATURE = feature(
     name = "all_warnings",
-    enabled = False,
+    enabled = True,
     flag_sets = [
         flag_set(
             actions = _CPP_ALL_COMPILE_ACTIONS + _C_ALL_COMPILE_ACTIONS,
@@ -128,7 +128,7 @@ _ALL_WARNINGS_FEATURE = feature(
 )
 _ALL_WARNINGS_AS_ERRORS_FEATURE = feature(
     name = "all_warnings_as_errors",
-    enabled = False,
+    enabled = True,
     flag_sets = [
         flag_set(
             actions = _CPP_ALL_COMPILE_ACTIONS + _C_ALL_COMPILE_ACTIONS,


### PR DESCRIPTION
I'm still learning my way around bazel-embedded but I thought we would prefer to build with `-Os` and `-g` to be able to generate annotated disassemblies by default. This, however, probably makes upstreaming this change harder. Looking forward to any ideas.

Related: lowRISC/opentitan#13150, lowRISC/opentitan#12552